### PR TITLE
Bugfix/remove npm folder test

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,28 +36,18 @@ else
 fi  
 
 cd /var/www/html/wp-content/themes/pcc
-if ! [[ -d "/var/www/html/wp-content/themes/pcc/node_modules" || -d "/var/www/html/wp-content/themes/pcc/vendor" ]]; then
-  echo "[ Install PCC theme ]"
-  npm install
-  composer install
-  npm run build:production
-else
-  echo "Run Composer and NPM"
-  npm run build:production
-  composer update
-fi
+echo "[ Install PCC theme dependencies ]"
+npm install
+composer install
+npm run build:production
+
 
 cd /var/www/html/wp-content/plugins/pcc-framework
-if ! [[ -d "/var/www/html/wp-content/plugins/pcc-framework/node_modules" || -d "/var/www/html/wp-content/plugins/pcc-framework/vendor" ]]; then
-  echo "[ Install PCC Plugin ]"
-  npm install
-  composer install
-  npm run build:production
-else
-  echo "Run Composer and NPM"
-  npm run build:production
-  composer update
-fi
+echo "[ Install PCC Plugin dependencies ]"
+npm install
+composer install
+npm run build:production
+
 
 cd /var/www/html
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ if ! [ -d "/var/www/html/wp-content/plugins/pcc-framework" ]; then
   git clone https://github.com/coopersystem-fsd/pcc-framework.git
 fi
 
-if [ "$ENV" == "prod" ]; then
+if [[ "$ENV" == "hom" || "$ENV" == "prod" ]]; then
   cd /var/www/html/wp-content/themes/pcc
   git checkout -f master
   echo "[ PCC theme - Branch: master ]"


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This is not a duplicate of an existing pull request

## Description

- Fix the file entrypoint.sh where it is tested if the directory node_modules exists to install the dependencies or not
- Fix the file entrypoint.sh to use the same git branch for hom and prod environments

## Steps to test

1. Go into root folder create .env file then type the command docker-compose up --build -d in cmd

**Expected behavior: Docker will created all the WordPress Structure and you can access the production environment